### PR TITLE
chore(media,postgres): update Kometa config and add postgres restore-test CronJob

### DIFF
--- a/apps/media/kometa/config.template.yml
+++ b/apps/media/kometa/config.template.yml
@@ -13,7 +13,7 @@ libraries:
       - default: universe                                   # Pixar, Disney Animated, DreamWorks, Studio Ghibli, Laika, Illumination, etc.
       - default: studio                                     # Collections by animation/production studio
       - default: decade                                     # 80s, 90s, 2000s, etc. — surfaces older animated classics
-      - default: content_rating_kids                        # Little Kids, Older Kids, Teens — built from Common Sense ratings
+      - default: content_rating_cs                           # Little Kids, Older Kids, Teens — built from Common Sense ratings
     remove_overlays: false                          # Set to true if you want to remove overlays
     reapply_overlays: false                         # Set to true if you want to force-reapply overlays to everything
       # THERE IS RARELY IF EVER A REASON TO DO THIS AS IT WILL EXTEND RUN TIMES ANS CAUSE IMAGE BLOAT
@@ -46,9 +46,8 @@ libraries:
     collection_files:
       - default: separator_chart                            # An "index card"
       - default: basic                                      # Some basic chart collections
-      - default: seasonal                                   # Christmas specials, Halloween episodes, etc.
       - default: network                                    # Disney Channel, Disney Junior, Cartoon Network, Nickelodeon, PBS Kids, etc.
-      - default: content_rating_kids                        # Little Kids, Older Kids, Teens — built from Common Sense ratings
+      - default: content_rating_cs                           # Little Kids, Older Kids, Teens — built from Common Sense ratings
     remove_overlays: false                          # Set to true if you want to remove overlays
     reapply_overlays: false                         # If you are doing a lot of testing and changes like me, keep this to true to always reapply overlays - can cause image bloat
     #reset_overlays: tmdb                           # if you want to reset the poster to default poster from tmdb - can cause image bloat

--- a/apps/media/kometa/cronjob.yaml
+++ b/apps/media/kometa/cronjob.yaml
@@ -19,12 +19,12 @@ spec:
               imagePullPolicy: IfNotPresent
               args: [ "--run", "--read-only-config" ]
               resources:
-                limits:
-                  cpu: 1000m
-                  memory: 2Gi
                 requests:
                   cpu: 500m
-                  memory: 1000Mi
+                  memory: 1Gi
+                limits:
+                  cpu: "2000m"
+                  memory: 2Gi
               volumeMounts:
                 - name: config
                   mountPath: /config

--- a/core/postgres/kustomization.yaml
+++ b/core/postgres/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - databases.yaml
   - backup-cronjob.yaml
   - grants-job.yaml
+  - restore-test-cronjob.yaml

--- a/core/postgres/restore-test-cronjob.yaml
+++ b/core/postgres/restore-test-cronjob.yaml
@@ -1,0 +1,143 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: shared-postgres-restore-test
+  namespace: postgres
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 80
+                preference:
+                  matchExpressions:
+                  - key: <node.kubernetes.io/pi-model>
+                    operator: In
+                    values:
+                    - "5"
+          restartPolicy: Never
+          tolerations:
+          - effect: NoExecute
+            key: <node.kubernetes.io/not-ready>
+            operator: Exists
+            tolerationSeconds: 30
+          - effect: NoExecute
+            key: <node.kubernetes.io/unreachable>
+            operator: Exists
+            tolerationSeconds: 30
+          containers:
+          - name: restore-test
+            image: postgres:18-alpine
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              BACKUP_DIR=/backup/shared
+              PGDATA=/pgdata/data
+              PASS=0
+              FAIL=0
+
+              echo "=== Postgres Backup Restore Test: $(date) ==="
+              echo ""
+
+              mkdir -p "$PGDATA"
+              chown -R postgres "$PGDATA"
+              su -s /bin/sh postgres -c "initdb -D '$PGDATA' -U postgres -A trust >/dev/null 2>&1"
+              su -s /bin/sh postgres -c "pg_ctl -D '$PGDATA' start -w -l /tmp/pg.log"
+              echo "Local Postgres ready."
+              echo ""
+
+              for DB in mealie radarr-main radarr-logs sonarr-main sonarr-logs prowlarr-main prowlarr-logs readarr-main readarr-logs lidarr-main lidarr-logs; do
+                LATEST=$(ls -t "${BACKUP_DIR}/${DB}_"*.dump 2>/dev/null | head -1 || true)
+
+                if [ -z "$LATEST" ]; then
+                  echo "[FAIL] $DB: no dump file found"
+                  FAIL=$((FAIL+1))
+                  continue
+                fi
+
+                DUMP_SIZE=$(du -sh "$LATEST" | cut -f1)
+                DUMP_AGE_H=$(( ( $(date +%s) - $(stat -c %Y "$LATEST") ) / 3600 ))
+
+                su -s /bin/sh postgres -c "createdb -h localhost -U postgres 'test_${DB}'" 2>/dev/null || true
+
+                su -s /bin/sh postgres -c "pg_restore -h localhost -U postgres -d 'test_${DB}' --no-owner --no-acl '$LATEST'" 2>/tmp/restore_err_${DB} \
+                  && RESTORE_OK=1 || RESTORE_OK=0
+
+                if [ "$RESTORE_OK" = "0" ] && grep -qi " error:" /tmp/restore_err_${DB} 2>/dev/null; then
+                  ERRMSG=$(grep -i " error:" /tmp/restore_err_${DB} | head -2 | tr '\n' ' ')
+                  echo "[FAIL] $DB  size=${DUMP_SIZE}  age=${DUMP_AGE_H}h  -- ${ERRMSG}"
+                  FAIL=$((FAIL+1))
+                  continue
+                fi
+
+                TABLES=$(su -s /bin/sh postgres -c \
+                  "psql -h localhost -U postgres -d 'test_${DB}' -tAc \
+                   \"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='public'\"" \
+                  2>/dev/null | tr -d ' \n' || echo "?")
+
+                ROWS_BACKUP=$(su -s /bin/sh postgres -c \
+                  "psql -h localhost -U postgres -d 'test_${DB}' -tAc \
+                   \"SELECT COALESCE(SUM(c.reltuples::bigint),0) FROM pg_class c \
+                     JOIN pg_namespace n ON n.oid=c.relnamespace \
+                     WHERE c.relkind='r' AND n.nspname='public'\"" \
+                  2>/dev/null | tr -d ' \n' || echo "?")
+
+                ROWS_LIVE=$(PGPASSWORD="$PGPASSWORD" psql \
+                  -h shared-postgres-rw -U "$PGUSER" -d "$DB" -tAc \
+                  "SELECT COALESCE(SUM(c.reltuples::bigint),0) FROM pg_class c \
+                   JOIN pg_namespace n ON n.oid=c.relnamespace \
+                   WHERE c.relkind='r' AND n.nspname='public'" \
+                  2>/dev/null | tr -d ' \n' || echo "N/A")
+
+                echo "[PASS] $DB  size=${DUMP_SIZE}  age=${DUMP_AGE_H}h  tables=${TABLES}  rows_backup~${ROWS_BACKUP}  rows_live~${ROWS_LIVE}"
+                PASS=$((PASS+1))
+              done
+
+              echo ""
+              echo "=== RESULT: ${PASS} passed, ${FAIL} failed ==="
+              echo "=== Completed: $(date) ==="
+
+              su -s /bin/sh postgres -c "pg_ctl -D '$PGDATA' stop -m fast" 2>/dev/null || true
+
+              [ "$FAIL" -eq 0 ]
+            env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: shared-postgres-app
+                  key: password
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: shared-postgres-app
+                  key: username
+            resources:
+              requests:
+                cpu: 200m
+                memory: 512Mi
+              limits:
+                cpu: "1"
+                memory: 1Gi
+            volumeMounts:
+            - name: pgbackup
+              mountPath: /backup
+              readOnly: true
+            - name: pgdata
+              mountPath: /pgdata
+          volumes:
+          - name: pgbackup
+            persistentVolumeClaim:
+              claimName: smb-pgbackup-shared-claim
+          - name: pgdata
+            emptyDir:
+              sizeLimit: 10Gi

--- a/core/postgres/restore-test-cronjob.yaml
+++ b/core/postgres/restore-test-cronjob.yaml
@@ -44,7 +44,7 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  set -eo pipefail
+                  set -e
                   BACKUP_DIR=/backup/shared
                   PGDATA=/pgdata/data
                   PASS=0
@@ -54,8 +54,10 @@ spec:
                   echo ""
 
                   mkdir -p "$PGDATA"
-                  initdb -D "$PGDATA" -U postgres -A trust >/dev/null 2>&1
-                  pg_ctl -D "$PGDATA" start -w -l /tmp/pg.log
+                  initdb -D "$PGDATA" -U postgres -A trust
+                  pg_ctl -D "$PGDATA" start -w -l /tmp/pg.log || {
+                    echo "pg_ctl start failed:"; tail -20 /tmp/pg.log; exit 1
+                  }
                   echo "Local Postgres ready."
                   echo ""
 
@@ -107,6 +109,7 @@ spec:
 
                     echo "[PASS] $DB  size=${DUMP_SIZE}  age=${DUMP_AGE_H}h  tables=${TABLES}  rows_backup~${ROWS_BACKUP}  rows_live~${ROWS_LIVE}"
                     PASS=$((PASS+1))
+                    dropdb -h localhost -U postgres "test_${DB}" 2>/dev/null || true
                   done
 
                   echo ""

--- a/core/postgres/restore-test-cronjob.yaml
+++ b/core/postgres/restore-test-cronjob.yaml
@@ -56,13 +56,22 @@ spec:
                   mkdir -p "$PGDATA"
                   initdb -D "$PGDATA" -U postgres -A trust
                   pg_ctl -D "$PGDATA" start -w -l /tmp/pg.log || {
-                    echo "pg_ctl start failed:"; tail -20 /tmp/pg.log; exit 1
+                    echo "pg_ctl start failed:"; tail -20 /tmp/pg.log 2>/dev/null || true; exit 1
                   }
                   echo "Local Postgres ready."
                   echo ""
 
-                  for DB in mealie radarr-main radarr-logs sonarr-main sonarr-logs prowlarr-main prowlarr-logs readarr-main readarr-logs lidarr-main lidarr-logs; do
-                    LATEST=$(ls -t "${BACKUP_DIR}/${DB}_"*.dump 2>/dev/null | head -1 || true)
+                  DBS=$(find "${BACKUP_DIR}" -maxdepth 1 -name "*.dump" 2>/dev/null \
+                    | sed 's|.*/||; s/_[0-9]\{8\}_[0-9]\{6\}\.dump$//' | sort -u)
+
+                  if [ -z "$DBS" ]; then
+                    echo "[FAIL] No dump files found in ${BACKUP_DIR}"
+                    exit 1
+                  fi
+
+                  for DB in $DBS; do
+                    LATEST=$(find "${BACKUP_DIR}" -maxdepth 1 -name "${DB}_*.dump" 2>/dev/null \
+                      | sort -r | head -1)
 
                     if [ -z "$LATEST" ]; then
                       echo "[FAIL] $DB: no dump file found"

--- a/core/postgres/restore-test-cronjob.yaml
+++ b/core/postgres/restore-test-cronjob.yaml
@@ -16,128 +16,133 @@ spec:
           affinity:
             nodeAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 80
-                preference:
-                  matchExpressions:
-                  - key: <node.kubernetes.io/pi-model>
-                    operator: In
-                    values:
-                    - "5"
+                - weight: 80
+                  preference:
+                    matchExpressions:
+                      - key: node.kubernetes.io/pi-model
+                        operator: In
+                        values:
+                          - "5"
           restartPolicy: Never
           tolerations:
-          - effect: NoExecute
-            key: <node.kubernetes.io/not-ready>
-            operator: Exists
-            tolerationSeconds: 30
-          - effect: NoExecute
-            key: <node.kubernetes.io/unreachable>
-            operator: Exists
-            tolerationSeconds: 30
+            - effect: NoExecute
+              key: node.kubernetes.io/not-ready
+              operator: Exists
+              tolerationSeconds: 30
+            - effect: NoExecute
+              key: node.kubernetes.io/unreachable
+              operator: Exists
+              tolerationSeconds: 30
           containers:
-          - name: restore-test
-            image: postgres:18-alpine
-            command:
-            - /bin/sh
-            - -c
-            - |
-              set -e
-              BACKUP_DIR=/backup/shared
-              PGDATA=/pgdata/data
-              PASS=0
-              FAIL=0
+            - name: restore-test
+              image: postgres:18-alpine
+              securityContext:
+                runAsUser: 0
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eo pipefail
+                  BACKUP_DIR=/backup/shared
+                  PGDATA=/pgdata/data
+                  PASS=0
+                  FAIL=0
 
-              echo "=== Postgres Backup Restore Test: $(date) ==="
-              echo ""
+                  echo "=== Postgres Backup Restore Test: $(date) ==="
+                  echo ""
 
-              mkdir -p "$PGDATA"
-              chown -R postgres "$PGDATA"
-              su -s /bin/sh postgres -c "initdb -D '$PGDATA' -U postgres -A trust >/dev/null 2>&1"
-              su -s /bin/sh postgres -c "pg_ctl -D '$PGDATA' start -w -l /tmp/pg.log"
-              echo "Local Postgres ready."
-              echo ""
+                  mkdir -p "$PGDATA"
+                  chown -R postgres "$PGDATA"
+                  su -s /bin/sh postgres -c "initdb -D '$PGDATA' -U postgres -A trust >/dev/null 2>&1"
+                  su -s /bin/sh postgres -c "pg_ctl -D '$PGDATA' start -w -l /tmp/pg.log"
+                  echo "Local Postgres ready."
+                  echo ""
 
-              for DB in mealie radarr-main radarr-logs sonarr-main sonarr-logs prowlarr-main prowlarr-logs readarr-main readarr-logs lidarr-main lidarr-logs; do
-                LATEST=$(ls -t "${BACKUP_DIR}/${DB}_"*.dump 2>/dev/null | head -1 || true)
+                  for DB in mealie radarr-main radarr-logs sonarr-main sonarr-logs prowlarr-main prowlarr-logs readarr-main readarr-logs lidarr-main lidarr-logs; do
+                    LATEST=$(ls -t "${BACKUP_DIR}/${DB}_"*.dump 2>/dev/null | head -1 || true)
 
-                if [ -z "$LATEST" ]; then
-                  echo "[FAIL] $DB: no dump file found"
-                  FAIL=$((FAIL+1))
-                  continue
-                fi
+                    if [ -z "$LATEST" ]; then
+                      echo "[FAIL] $DB: no dump file found"
+                      FAIL=$((FAIL+1))
+                      continue
+                    fi
 
-                DUMP_SIZE=$(du -sh "$LATEST" | cut -f1)
-                DUMP_AGE_H=$(( ( $(date +%s) - $(stat -c %Y "$LATEST") ) / 3600 ))
+                    DUMP_SIZE=$(du -sh "$LATEST" | cut -f1)
+                    DUMP_AGE_H=$(( ( $(date +%s) - $(stat -c %Y "$LATEST") ) / 3600 ))
 
-                su -s /bin/sh postgres -c "createdb -h localhost -U postgres 'test_${DB}'" 2>/dev/null || true
+                    su -s /bin/sh postgres -c "createdb -h localhost -U postgres 'test_${DB}'" 2>/dev/null || true
 
-                su -s /bin/sh postgres -c "pg_restore -h localhost -U postgres -d 'test_${DB}' --no-owner --no-acl '$LATEST'" 2>/tmp/restore_err_${DB} \
-                  && RESTORE_OK=1 || RESTORE_OK=0
+                    su -s /bin/sh postgres -c "pg_restore -h localhost -U postgres -d 'test_${DB}' --no-owner --no-acl '$LATEST'" 2>/tmp/restore_err_${DB} \
+                      && RESTORE_OK=1 || RESTORE_OK=0
 
-                if [ "$RESTORE_OK" = "0" ] && grep -qi " error:" /tmp/restore_err_${DB} 2>/dev/null; then
-                  ERRMSG=$(grep -i " error:" /tmp/restore_err_${DB} | head -2 | tr '\n' ' ')
-                  echo "[FAIL] $DB  size=${DUMP_SIZE}  age=${DUMP_AGE_H}h  -- ${ERRMSG}"
-                  FAIL=$((FAIL+1))
-                  continue
-                fi
+                    if [ "$RESTORE_OK" = "0" ] && grep -qi " error:" /tmp/restore_err_${DB} 2>/dev/null; then
+                      ERRMSG=$(grep -i " error:" /tmp/restore_err_${DB} | head -2 | tr '\n' ' ')
+                      echo "[FAIL] $DB  size=${DUMP_SIZE}  age=${DUMP_AGE_H}h  -- ${ERRMSG}"
+                      FAIL=$((FAIL+1))
+                      continue
+                    fi
 
-                TABLES=$(su -s /bin/sh postgres -c \
-                  "psql -h localhost -U postgres -d 'test_${DB}' -tAc \
-                   \"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='public'\"" \
-                  2>/dev/null | tr -d ' \n' || echo "?")
+                    TABLES=$(su -s /bin/sh postgres -c \
+                      "psql -h localhost -U postgres -d 'test_${DB}' -tAc \
+                       \"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='public'\""  \
+                      2>/dev/null || echo "?")
+                    TABLES=$(echo "$TABLES" | tr -d ' \n')
 
-                ROWS_BACKUP=$(su -s /bin/sh postgres -c \
-                  "psql -h localhost -U postgres -d 'test_${DB}' -tAc \
-                   \"SELECT COALESCE(SUM(c.reltuples::bigint),0) FROM pg_class c \
-                     JOIN pg_namespace n ON n.oid=c.relnamespace \
-                     WHERE c.relkind='r' AND n.nspname='public'\"" \
-                  2>/dev/null | tr -d ' \n' || echo "?")
+                    ROWS_BACKUP=$(su -s /bin/sh postgres -c \
+                      "psql -h localhost -U postgres -d 'test_${DB}' -tAc \
+                       \"SELECT COALESCE(SUM(c.reltuples::bigint),0) FROM pg_class c \
+                         JOIN pg_namespace n ON n.oid=c.relnamespace \
+                         WHERE c.relkind='r' AND n.nspname='public'\""  \
+                      2>/dev/null || echo "?")
+                    ROWS_BACKUP=$(echo "$ROWS_BACKUP" | tr -d ' \n')
 
-                ROWS_LIVE=$(PGPASSWORD="$PGPASSWORD" psql \
-                  -h shared-postgres-rw -U "$PGUSER" -d "$DB" -tAc \
-                  "SELECT COALESCE(SUM(c.reltuples::bigint),0) FROM pg_class c \
-                   JOIN pg_namespace n ON n.oid=c.relnamespace \
-                   WHERE c.relkind='r' AND n.nspname='public'" \
-                  2>/dev/null | tr -d ' \n' || echo "N/A")
+                    ROWS_LIVE=$(PGPASSWORD="$PGPASSWORD" psql \
+                      -h shared-postgres-rw -U "$PGUSER" -d "$DB" -tAc \
+                      "SELECT COALESCE(SUM(c.reltuples::bigint),0) FROM pg_class c \
+                       JOIN pg_namespace n ON n.oid=c.relnamespace \
+                       WHERE c.relkind='r' AND n.nspname='public'" \
+                      2>/dev/null || echo "N/A")
+                    ROWS_LIVE=$(echo "$ROWS_LIVE" | tr -d ' \n')
 
-                echo "[PASS] $DB  size=${DUMP_SIZE}  age=${DUMP_AGE_H}h  tables=${TABLES}  rows_backup~${ROWS_BACKUP}  rows_live~${ROWS_LIVE}"
-                PASS=$((PASS+1))
-              done
+                    echo "[PASS] $DB  size=${DUMP_SIZE}  age=${DUMP_AGE_H}h  tables=${TABLES}  rows_backup~${ROWS_BACKUP}  rows_live~${ROWS_LIVE}"
+                    PASS=$((PASS+1))
+                  done
 
-              echo ""
-              echo "=== RESULT: ${PASS} passed, ${FAIL} failed ==="
-              echo "=== Completed: $(date) ==="
+                  echo ""
+                  echo "=== RESULT: ${PASS} passed, ${FAIL} failed ==="
+                  echo "=== Completed: $(date) ==="
 
-              su -s /bin/sh postgres -c "pg_ctl -D '$PGDATA' stop -m fast" 2>/dev/null || true
+                  su -s /bin/sh postgres -c "pg_ctl -D '$PGDATA' stop -m fast" 2>/dev/null || true
 
-              [ "$FAIL" -eq 0 ]
-            env:
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: shared-postgres-app
-                  key: password
-            - name: PGUSER
-              valueFrom:
-                secretKeyRef:
-                  name: shared-postgres-app
-                  key: username
-            resources:
-              requests:
-                cpu: 200m
-                memory: 512Mi
-              limits:
-                cpu: "1"
-                memory: 1Gi
-            volumeMounts:
-            - name: pgbackup
-              mountPath: /backup
-              readOnly: true
-            - name: pgdata
-              mountPath: /pgdata
+                  [ "$FAIL" -eq 0 ]
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: shared-postgres-app
+                      key: password
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: shared-postgres-app
+                      key: username
+              resources:
+                requests:
+                  cpu: 200m
+                  memory: 512Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+              volumeMounts:
+                - name: pgbackup
+                  mountPath: /backup
+                  readOnly: true
+                - name: pgdata
+                  mountPath: /pgdata
           volumes:
-          - name: pgbackup
-            persistentVolumeClaim:
-              claimName: smb-pgbackup-shared-claim
-          - name: pgdata
-            emptyDir:
-              sizeLimit: 10Gi
+            - name: pgbackup
+              persistentVolumeClaim:
+                claimName: smb-pgbackup-shared-claim
+            - name: pgdata
+              emptyDir:
+                sizeLimit: 10Gi

--- a/core/postgres/restore-test-cronjob.yaml
+++ b/core/postgres/restore-test-cronjob.yaml
@@ -83,6 +83,7 @@ spec:
                     if ! pg_restore -h localhost -U postgres -d "test_${DB}" --no-owner --no-acl "$LATEST" 2>/tmp/restore_err_${DB}; then
                       ERRMSG=$(head -2 /tmp/restore_err_${DB} | tr '\n' ' ')
                       echo "[FAIL] $DB  size=${DUMP_SIZE}  age=${DUMP_AGE_H}h  -- ${ERRMSG}"
+                      dropdb -h localhost -U postgres "test_${DB}" 2>/dev/null || true
                       FAIL=$((FAIL+1))
                       continue
                     fi
@@ -99,7 +100,7 @@ spec:
                       2>/dev/null || echo "?")
                     ROWS_BACKUP=$(echo "$ROWS_BACKUP" | tr -d ' \n')
 
-                    ROWS_LIVE=$(PGPASSWORD="$PGPASSWORD" psql \
+                    ROWS_LIVE=$(psql \
                       -h shared-postgres-rw -U "$PGUSER" -d "$DB" -tAc \
                       "SELECT COALESCE(SUM(c.reltuples::bigint),0) FROM pg_class c \
                        JOIN pg_namespace n ON n.oid=c.relnamespace \
@@ -120,16 +121,8 @@ spec:
 
                   [ "$FAIL" -eq 0 ]
               env:
-                - name: PGPASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: shared-postgres-app
-                      key: password
                 - name: PGUSER
-                  valueFrom:
-                    secretKeyRef:
-                      name: shared-postgres-app
-                      key: username
+                  value: backup
               resources:
                 requests:
                   cpu: 200m

--- a/core/postgres/restore-test-cronjob.yaml
+++ b/core/postgres/restore-test-cronjob.yaml
@@ -13,6 +13,10 @@ spec:
       backoffLimit: 0
       template:
         spec:
+          securityContext:
+            runAsUser: 70
+            runAsGroup: 70
+            fsGroup: 70
           affinity:
             nodeAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
@@ -36,8 +40,6 @@ spec:
           containers:
             - name: restore-test
               image: postgres:18-alpine
-              securityContext:
-                runAsUser: 0
               command:
                 - /bin/sh
                 - -c
@@ -52,9 +54,8 @@ spec:
                   echo ""
 
                   mkdir -p "$PGDATA"
-                  chown -R postgres "$PGDATA"
-                  su -s /bin/sh postgres -c "initdb -D '$PGDATA' -U postgres -A trust >/dev/null 2>&1"
-                  su -s /bin/sh postgres -c "pg_ctl -D '$PGDATA' start -w -l /tmp/pg.log"
+                  initdb -D "$PGDATA" -U postgres -A trust >/dev/null 2>&1
+                  pg_ctl -D "$PGDATA" start -w -l /tmp/pg.log
                   echo "Local Postgres ready."
                   echo ""
 
@@ -70,29 +71,29 @@ spec:
                     DUMP_SIZE=$(du -sh "$LATEST" | cut -f1)
                     DUMP_AGE_H=$(( ( $(date +%s) - $(stat -c %Y "$LATEST") ) / 3600 ))
 
-                    su -s /bin/sh postgres -c "createdb -h localhost -U postgres 'test_${DB}'" 2>/dev/null || true
+                    if ! createdb -h localhost -U postgres "test_${DB}" 2>/tmp/restore_err_${DB}; then
+                      ERRMSG=$(head -2 /tmp/restore_err_${DB} | tr '\n' ' ')
+                      echo "[FAIL] $DB: createdb failed -- ${ERRMSG}"
+                      FAIL=$((FAIL+1))
+                      continue
+                    fi
 
-                    su -s /bin/sh postgres -c "pg_restore -h localhost -U postgres -d 'test_${DB}' --no-owner --no-acl '$LATEST'" 2>/tmp/restore_err_${DB} \
-                      && RESTORE_OK=1 || RESTORE_OK=0
-
-                    if [ "$RESTORE_OK" = "0" ] && grep -qi " error:" /tmp/restore_err_${DB} 2>/dev/null; then
-                      ERRMSG=$(grep -i " error:" /tmp/restore_err_${DB} | head -2 | tr '\n' ' ')
+                    if ! pg_restore -h localhost -U postgres -d "test_${DB}" --no-owner --no-acl "$LATEST" 2>/tmp/restore_err_${DB}; then
+                      ERRMSG=$(head -2 /tmp/restore_err_${DB} | tr '\n' ' ')
                       echo "[FAIL] $DB  size=${DUMP_SIZE}  age=${DUMP_AGE_H}h  -- ${ERRMSG}"
                       FAIL=$((FAIL+1))
                       continue
                     fi
 
-                    TABLES=$(su -s /bin/sh postgres -c \
-                      "psql -h localhost -U postgres -d 'test_${DB}' -tAc \
-                       \"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='public'\""  \
+                    TABLES=$(psql -h localhost -U postgres -d "test_${DB}" -tAc \
+                      "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='public'" \
                       2>/dev/null || echo "?")
                     TABLES=$(echo "$TABLES" | tr -d ' \n')
 
-                    ROWS_BACKUP=$(su -s /bin/sh postgres -c \
-                      "psql -h localhost -U postgres -d 'test_${DB}' -tAc \
-                       \"SELECT COALESCE(SUM(c.reltuples::bigint),0) FROM pg_class c \
-                         JOIN pg_namespace n ON n.oid=c.relnamespace \
-                         WHERE c.relkind='r' AND n.nspname='public'\""  \
+                    ROWS_BACKUP=$(psql -h localhost -U postgres -d "test_${DB}" -tAc \
+                      "SELECT COALESCE(SUM(c.reltuples::bigint),0) FROM pg_class c \
+                       JOIN pg_namespace n ON n.oid=c.relnamespace \
+                       WHERE c.relkind='r' AND n.nspname='public'" \
                       2>/dev/null || echo "?")
                     ROWS_BACKUP=$(echo "$ROWS_BACKUP" | tr -d ' \n')
 
@@ -112,7 +113,7 @@ spec:
                   echo "=== RESULT: ${PASS} passed, ${FAIL} failed ==="
                   echo "=== Completed: $(date) ==="
 
-                  su -s /bin/sh postgres -c "pg_ctl -D '$PGDATA' stop -m fast" 2>/dev/null || true
+                  pg_ctl -D "$PGDATA" stop -m fast 2>/dev/null || true
 
                   [ "$FAIL" -eq 0 ]
               env:

--- a/core/postgres/restore-test-cronjob.yaml
+++ b/core/postgres/restore-test-cronjob.yaml
@@ -54,7 +54,7 @@ spec:
                   echo ""
 
                   mkdir -p "$PGDATA"
-                  initdb -D "$PGDATA" -U postgres -A trust
+                  initdb -D "$PGDATA" -U postgres -A trust --auth-host=trust
                   pg_ctl -D "$PGDATA" start -w -l /tmp/pg.log || {
                     echo "pg_ctl start failed:"; tail -20 /tmp/pg.log 2>/dev/null || true; exit 1
                   }

--- a/core/postgres/restore-test-cronjob.yaml
+++ b/core/postgres/restore-test-cronjob.yaml
@@ -108,7 +108,13 @@ spec:
                       2>/dev/null || echo "N/A")
                     ROWS_LIVE=$(echo "$ROWS_LIVE" | tr -d ' \n')
 
-                    echo "[PASS] $DB  size=${DUMP_SIZE}  age=${DUMP_AGE_H}h  tables=${TABLES}  rows_backup~${ROWS_BACKUP}  rows_live~${ROWS_LIVE}"
+                    TABLES_LIVE=$(psql \
+                      -h shared-postgres-rw -U "$PGUSER" -d "$DB" -tAc \
+                      "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='public'" \
+                      2>/dev/null || echo "N/A")
+                    TABLES_LIVE=$(echo "$TABLES_LIVE" | tr -d ' \n')
+
+                    echo "[PASS] $DB  size=${DUMP_SIZE}  age=${DUMP_AGE_H}h  tables=${TABLES}(live:${TABLES_LIVE})  rows_backup~${ROWS_BACKUP}  rows_live~${ROWS_LIVE}"
                     PASS=$((PASS+1))
                     dropdb -h localhost -U postgres "test_${DB}" 2>/dev/null || true
                   done


### PR DESCRIPTION
## Changes

### Kometa (media namespace)
- Replace `content_rating_kids` with `content_rating_cs` in both Movies and TV Shows `collection_files`
- Remove `seasonal` from TV Shows `collection_files` (seasonal collections only exist for movies)
- Increase CronJob CPU limit from `1000m` to `2000m` to eliminate throttling; normalize memory request to `1Gi`

### Postgres (postgres namespace)
- Add `shared-postgres-restore-test` CronJob — runs nightly at 03:00, restores the latest `pg_dump` backup per database into a temporary local Postgres instance, and logs table/row counts alongside the live cluster counts for informational comparison; exits non-zero if any restore fails

https://claude.ai/code/session_01GF8uxyRTp3kUESM2Deh5cB