### PR TITLE
fix(postgres): use shared-postgres-app secret for backup CronJob credentials

### DIFF
--- a/core/postgres/backup-cronjob.yaml
+++ b/core/postgres/backup-cronjob.yaml
@@ -18,8 +18,16 @@ spec:
             - name: pg-dump
               image: postgres:18-alpine
               env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: shared-postgres-app
+                      key: password
                 - name: PGUSER
-                  value: backup
+                  valueFrom:
+                    secretKeyRef:
+                      name: shared-postgres-app
+                      key: username
               command:
                 - /bin/sh
                 - -c


### PR DESCRIPTION
## Changes

- Replace hardcoded `PGUSER: backup` in the `shared-postgres-backup` CronJob with `PGPASSWORD` and `PGUSER` sourced from the `shared-postgres-app` secret, consistent with the restore-test CronJob

https://claude.ai/code/session_01GF8uxyRTp3kUESM2Deh5cB

---
_Generated by [Claude Code](https://claude.ai/code/session_01GF8uxyRTp3kUESM2Deh5cB)_