### PR TITLE
fix(postgres): reassign superuser-owned objects in outline db to outline role

### DIFF
--- a/core/postgres/grants-job.yaml
+++ b/core/postgres/grants-job.yaml
@@ -44,6 +44,9 @@ spec:
                 GRANT pg_read_all_data TO backup;
               END $$;
               ENDSQL
+              # Reassign any superuser-owned objects in the outline database to the outline role
+              # so that Outline's migrations can run ALTER TABLE statements successfully.
+              psql -h shared-postgres-rw -U "$PGUSER" -d outline -c "REASSIGN OWNED BY \"$PGUSER\" TO outline;"
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
Outline's migration 20260411000000-add-title-and-iconUrl-to-shares.js fails
with "must be owner of table shares" because some tables were created by the
superuser rather than the outline role. Adding REASSIGN OWNED BY to the
grants job fixes table ownership so ALTER TABLE migrations can succeed.

https://claude.ai/code/session_01Mhjuv59wbBJ6bqYJ4kShzT