### PR TITLE
fix(outline): reassign db table ownership to fix migration error

### DIFF
--- a/core/postgres/kustomization.yaml
+++ b/core/postgres/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - databases.yaml
   - backup-cronjob.yaml
   - grants-job.yaml
+  - outline-ownership-fix.yaml
   - restore-test-cronjob.yaml

--- a/core/postgres/outline-ownership-fix.yaml
+++ b/core/postgres/outline-ownership-fix.yaml
@@ -30,7 +30,31 @@ spec:
             - -c
             - |
               set -e
-              psql -h shared-postgres-rw -U "$PGUSER" -d outline -c "REASSIGN OWNED BY \"$PGUSER\" TO outline;"
+              until psql -h shared-postgres-rw -U "$PGUSER" -d postgres -tAc \
+                "SELECT 1 FROM pg_database WHERE datname='outline'" 2>/dev/null | grep -q 1; do
+                echo "Waiting for outline database..."; sleep 5
+              done
+              psql -h shared-postgres-rw -U "$PGUSER" -d outline << 'ENDSQL'
+              DO $$
+              DECLARE obj RECORD;
+              BEGIN
+                FOR obj IN
+                  SELECT c.relname, c.relkind
+                  FROM pg_class c
+                  JOIN pg_namespace n ON n.oid = c.relnamespace
+                  JOIN pg_roles r ON r.oid = c.relowner
+                  WHERE n.nspname = 'public'
+                    AND c.relkind IN ('r', 'S')
+                    AND r.rolname != 'outline'
+                LOOP
+                  IF obj.relkind = 'r' THEN
+                    EXECUTE format('ALTER TABLE public.%I OWNER TO outline', obj.relname);
+                  ELSE
+                    EXECUTE format('ALTER SEQUENCE public.%I OWNER TO outline', obj.relname);
+                  END IF;
+                END LOOP;
+              END $$;
+              ENDSQL
           resources:
             requests:
               cpu: 10m

--- a/core/postgres/outline-ownership-fix.yaml
+++ b/core/postgres/outline-ownership-fix.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: shared-postgres-backup-grants
+  name: outline-ownership-fix
   namespace: postgres
   annotations:
     argocd.argoproj.io/hook: PostSync
@@ -12,7 +12,7 @@ spec:
     spec:
       restartPolicy: OnFailure
       containers:
-        - name: grants
+        - name: fix-ownership
           image: postgres:18-alpine
           env:
             - name: PGPASSWORD
@@ -30,20 +30,7 @@ spec:
             - -c
             - |
               set -e
-              psql -h shared-postgres-rw -U "$PGUSER" -d postgres << 'ENDSQL'
-              DO $$
-              DECLARE
-                db RECORD;
-              BEGIN
-                FOR db IN
-                  SELECT datname FROM pg_database
-                  WHERE datistemplate = false AND datname NOT IN ('postgres')
-                LOOP
-                  EXECUTE format('GRANT CONNECT ON DATABASE %I TO backup', db.datname);
-                END LOOP;
-                GRANT pg_read_all_data TO backup;
-              END $$;
-              ENDSQL
+              psql -h shared-postgres-rw -U "$PGUSER" -d outline -c "REASSIGN OWNED BY \"$PGUSER\" TO outline;"
           resources:
             requests:
               cpu: 10m

--- a/core/postgres/restore-test-cronjob.yaml
+++ b/core/postgres/restore-test-cronjob.yaml
@@ -136,16 +136,8 @@ spec:
 
                   [ "$FAIL" -eq 0 ]
               env:
-                - name: PGPASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: shared-postgres-superuser
-                      key: password
                 - name: PGUSER
-                  valueFrom:
-                    secretKeyRef:
-                      name: shared-postgres-superuser
-                      key: username
+                  value: backup
               resources:
                 requests:
                   cpu: 200m

--- a/core/postgres/restore-test-cronjob.yaml
+++ b/core/postgres/restore-test-cronjob.yaml
@@ -136,8 +136,16 @@ spec:
 
                   [ "$FAIL" -eq 0 ]
               env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: shared-postgres-superuser
+                      key: password
                 - name: PGUSER
-                  value: backup
+                  valueFrom:
+                    secretKeyRef:
+                      name: shared-postgres-superuser
+                      key: username
               resources:
                 requests:
                   cpu: 200m


### PR DESCRIPTION
## Summary

- Adds a dedicated PostSync job (`core/postgres/outline-ownership-fix.yaml`) that runs `REASSIGN OWNED BY <superuser> TO outline` against the outline database
- Fixes migration failure: `Migration 20260411000000-add-title-and-iconUrl-to-shares.js (up) failed: Original error: must be owner of table shares`
- Root cause: tables were created by the PostgreSQL superuser rather than the `outline` role, preventing `ALTER TABLE` statements in migrations from succeeding

## Test plan

- [ ] Merge and sync the `core/postgres` ArgoCD app to trigger the PostSync job
- [ ] Confirm the `outline-ownership-fix` job completes successfully in the `postgres` namespace
- [ ] Restart the Outline pod and confirm the migration runs without error
- [ ] Verify Outline is accessible and no longer returns 502

https://claude.ai/code/session_01Mhjuv59wbBJ6bqYJ4kShzT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mhjuv59wbBJ6bqYJ4kShzT)_