### PR TITLE
fix(postgres): use trust auth for backup CronJob to fix ArgoCD sync

### DIFF
--- a/core/postgres/backup-cronjob.yaml
+++ b/core/postgres/backup-cronjob.yaml
@@ -18,16 +18,8 @@ spec:
             - name: pg-dump
               image: postgres:18-alpine
               env:
-                - name: PGPASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: shared-postgres-app
-                      key: password
                 - name: PGUSER
-                  valueFrom:
-                    secretKeyRef:
-                      name: shared-postgres-app
-                      key: username
+                  value: backup
               command:
                 - /bin/sh
                 - -c


### PR DESCRIPTION
## Summary

- Reverts `backup-cronjob.yaml` from `shared-postgres-app` secret credentials back to `PGUSER=backup` with trust auth
- The cluster has no `bootstrap` section in `cluster.yaml`, so `shared-postgres-app` has no configured app user — `PGPASSWORD` and `PGUSER` both resolve to `''`, causing ArgoCD to fail syncing the postgres app with an empty env value error
- `PGUSER=backup` with `host all backup all trust` in pg_hba (already in `cluster.yaml`) is the correct approach, consistent with how `restore-test-cronjob.yaml` already works

## Test plan

- [ ] Merge and sync the `core/postgres` ArgoCD app
- [ ] Confirm the sync succeeds with no empty env value errors
- [ ] Confirm the backup CronJob runs successfully at its next scheduled time (or trigger manually)

https://claude.ai/code/session_01Mhjuv59wbBJ6bqYJ4kShzT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mhjuv59wbBJ6bqYJ4kShzT)_