### PR TITLE
fix(outline): simplify ownership fix to REASSIGN OWNED BY CURRENT_USER

### DIFF
--- a/core/postgres/outline-ownership-fix.yaml
+++ b/core/postgres/outline-ownership-fix.yaml
@@ -34,27 +34,7 @@ spec:
                 "SELECT 1 FROM pg_database WHERE datname='outline'" 2>/dev/null | grep -q 1; do
                 echo "Waiting for outline database..."; sleep 5
               done
-              psql -h shared-postgres-rw -U "$PGUSER" -d outline << 'ENDSQL'
-              DO $$
-              DECLARE obj RECORD;
-              BEGIN
-                FOR obj IN
-                  SELECT c.relname, c.relkind
-                  FROM pg_class c
-                  JOIN pg_namespace n ON n.oid = c.relnamespace
-                  JOIN pg_roles r ON r.oid = c.relowner
-                  WHERE n.nspname = 'public'
-                    AND c.relkind IN ('r', 'S')
-                    AND r.rolname != 'outline'
-                LOOP
-                  IF obj.relkind = 'r' THEN
-                    EXECUTE format('ALTER TABLE public.%I OWNER TO outline', obj.relname);
-                  ELSE
-                    EXECUTE format('ALTER SEQUENCE public.%I OWNER TO outline', obj.relname);
-                  END IF;
-                END LOOP;
-              END $$;
-              ENDSQL
+              psql -h shared-postgres-rw -U "$PGUSER" -d outline -c "REASSIGN OWNED BY CURRENT_USER TO outline;"
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary

- Replaces the targeted DO block with `REASSIGN OWNED BY CURRENT_USER TO outline`
- The previous DO block only handled `relkind IN ('r', 'S')` and could silently succeed without actually fixing the ownership if there were any edge cases
- `REASSIGN OWNED BY` is comprehensive (covers all object types), idempotent (no-op if outline already owns everything), and is the right tool for this job

## Why the previous fix may not have worked

The outline-ownership-fix PostSync job only runs when the `core/postgres` ArgoCD app is synced. If the app hasn't been synced since PR #410 merged, the job has not run yet. **After merging this PR, manually sync the `core/postgres` app in ArgoCD to trigger the job.**

## Test plan

- [ ] Merge and manually sync the `core/postgres` ArgoCD app
- [ ] Confirm the `outline-ownership-fix` job completes successfully
- [ ] Restart the Outline pod — migration should succeed and Outline should come up

https://claude.ai/code/session_01Mhjuv59wbBJ6bqYJ4kShzT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mhjuv59wbBJ6bqYJ4kShzT)_