### PR TITLE
fix(outline): correct ownership fix to cover all public schema object types

### DIFF
--- a/core/postgres/outline-ownership-fix.yaml
+++ b/core/postgres/outline-ownership-fix.yaml
@@ -34,7 +34,29 @@ spec:
                 "SELECT 1 FROM pg_database WHERE datname='outline'" 2>/dev/null | grep -q 1; do
                 echo "Waiting for outline database..."; sleep 5
               done
-              psql -h shared-postgres-rw -U "$PGUSER" -d outline -c "REASSIGN OWNED BY CURRENT_USER TO outline;"
+              psql -h shared-postgres-rw -U "$PGUSER" -d outline << 'ENDSQL'
+              DO $$
+              DECLARE obj RECORD;
+              BEGIN
+                FOR obj IN
+                  SELECT c.relname, c.relkind
+                  FROM pg_class c
+                  JOIN pg_namespace n ON n.oid = c.relnamespace
+                  JOIN pg_roles r ON r.oid = c.relowner
+                  WHERE n.nspname = 'public'
+                    AND c.relkind IN ('r', 'S', 'v', 'm', 'p')
+                    AND r.rolname != 'outline'
+                LOOP
+                  IF obj.relkind = 'S' THEN
+                    EXECUTE format('ALTER SEQUENCE public.%I OWNER TO outline', obj.relname);
+                  ELSIF obj.relkind = 'm' THEN
+                    EXECUTE format('ALTER MATERIALIZED VIEW public.%I OWNER TO outline', obj.relname);
+                  ELSE
+                    EXECUTE format('ALTER TABLE public.%I OWNER TO outline', obj.relname);
+                  END IF;
+                END LOOP;
+              END $$;
+              ENDSQL
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary

- Extends the `outline-ownership-fix` DO block to cover views (`v`), materialized views (`m`), and partitioned tables (`p`) in addition to regular tables and sequences
- Uses the correct `ALTER` command per object type: `ALTER SEQUENCE` for sequences, `ALTER MATERIALIZED VIEW` for materialized views, `ALTER TABLE` for everything else
- Stays scoped to the `public` schema only — avoids touching system objects that caused the previous `REASSIGN OWNED BY CURRENT_USER` approach to fail

## Test plan

- [ ] Merge and sync the `core/postgres` ArgoCD app
- [ ] Confirm the `outline-ownership-fix` job completes successfully
- [ ] Restart the Outline pod and confirm the migration succeeds

https://claude.ai/code/session_01Mhjuv59wbBJ6bqYJ4kShzT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mhjuv59wbBJ6bqYJ4kShzT)_