### PR TITLE
fix(outline): fix ownership job to transfer superuser-owned objects to outline role

### DIFF
--- a/core/postgres/outline-ownership-fix.yaml
+++ b/core/postgres/outline-ownership-fix.yaml
@@ -31,9 +31,15 @@ spec:
             - |
               set -e
               set -o pipefail
+              ATTEMPTS=0
               until psql -h shared-postgres-rw -U "$PGUSER" -d postgres -tAc \
                 "SELECT 1 FROM pg_database WHERE datname='outline'" 2>/dev/null | grep -q 1; do
-                echo "Waiting for outline database..."; sleep 5
+                ATTEMPTS=$((ATTEMPTS + 1))
+                if [ "$ATTEMPTS" -ge 30 ]; then
+                  echo "Timed out waiting for outline database after 30 attempts"
+                  exit 1
+                fi
+                echo "Waiting for outline database... (attempt ${ATTEMPTS}/30)"; sleep 5
               done
               psql -h shared-postgres-rw -U "$PGUSER" -d outline -tAc \
                 "SELECT format(
@@ -48,8 +54,12 @@ spec:
                  JOIN pg_roles r ON r.oid = c.relowner
                  WHERE n.nspname = 'public'
                    AND c.relkind IN ('r', 'S', 'v', 'm', 'p')
-                   AND r.rolname = current_user" \
-                | psql -h shared-postgres-rw -U "$PGUSER" -d outline -v ON_ERROR_STOP=1
+                   AND r.rolname = current_user
+                   AND NOT EXISTS (
+                     SELECT 1 FROM pg_depend
+                     WHERE objid = c.oid AND deptype = 'e'
+                   )" \
+                | psql -h shared-postgres-rw -U "$PGUSER" -d outline -1 -v ON_ERROR_STOP=1
           resources:
             requests:
               cpu: 10m

--- a/core/postgres/outline-ownership-fix.yaml
+++ b/core/postgres/outline-ownership-fix.yaml
@@ -34,29 +34,20 @@ spec:
                 "SELECT 1 FROM pg_database WHERE datname='outline'" 2>/dev/null | grep -q 1; do
                 echo "Waiting for outline database..."; sleep 5
               done
-              psql -h shared-postgres-rw -U "$PGUSER" -d outline << 'ENDSQL'
-              DO $$
-              DECLARE obj RECORD;
-              BEGIN
-                FOR obj IN
-                  SELECT c.relname, c.relkind
-                  FROM pg_class c
-                  JOIN pg_namespace n ON n.oid = c.relnamespace
-                  JOIN pg_roles r ON r.oid = c.relowner
-                  WHERE n.nspname = 'public'
-                    AND c.relkind IN ('r', 'S', 'v', 'm', 'p')
-                    AND r.rolname != 'outline'
-                LOOP
-                  IF obj.relkind = 'S' THEN
-                    EXECUTE format('ALTER SEQUENCE public.%I OWNER TO outline', obj.relname);
-                  ELSIF obj.relkind = 'm' THEN
-                    EXECUTE format('ALTER MATERIALIZED VIEW public.%I OWNER TO outline', obj.relname);
-                  ELSE
-                    EXECUTE format('ALTER TABLE public.%I OWNER TO outline', obj.relname);
-                  END IF;
-                END LOOP;
-              END $$;
-              ENDSQL
+              psql -h shared-postgres-rw -U "$PGUSER" -d outline -tAc \
+                "SELECT format(
+                   CASE c.relkind
+                     WHEN 'S' THEN 'ALTER SEQUENCE public.%I OWNER TO outline;'
+                     WHEN 'm' THEN 'ALTER MATERIALIZED VIEW public.%I OWNER TO outline;'
+                     ELSE 'ALTER TABLE public.%I OWNER TO outline;'
+                   END, c.relname)
+                 FROM pg_class c
+                 JOIN pg_namespace n ON n.oid = c.relnamespace
+                 JOIN pg_roles r ON r.oid = c.relowner
+                 WHERE n.nspname = 'public'
+                   AND c.relkind IN ('r', 'S', 'v', 'm', 'p')
+                   AND r.rolname != 'outline'" \
+                | psql -h shared-postgres-rw -U "$PGUSER" -d outline
           resources:
             requests:
               cpu: 10m

--- a/core/postgres/outline-ownership-fix.yaml
+++ b/core/postgres/outline-ownership-fix.yaml
@@ -30,6 +30,7 @@ spec:
             - -c
             - |
               set -e
+              set -o pipefail
               until psql -h shared-postgres-rw -U "$PGUSER" -d postgres -tAc \
                 "SELECT 1 FROM pg_database WHERE datname='outline'" 2>/dev/null | grep -q 1; do
                 echo "Waiting for outline database..."; sleep 5
@@ -38,6 +39,7 @@ spec:
                 "SELECT format(
                    CASE c.relkind
                      WHEN 'S' THEN 'ALTER SEQUENCE public.%I OWNER TO outline;'
+                     WHEN 'v' THEN 'ALTER VIEW public.%I OWNER TO outline;'
                      WHEN 'm' THEN 'ALTER MATERIALIZED VIEW public.%I OWNER TO outline;'
                      ELSE 'ALTER TABLE public.%I OWNER TO outline;'
                    END, c.relname)
@@ -46,8 +48,8 @@ spec:
                  JOIN pg_roles r ON r.oid = c.relowner
                  WHERE n.nspname = 'public'
                    AND c.relkind IN ('r', 'S', 'v', 'm', 'p')
-                   AND r.rolname != 'outline'" \
-                | psql -h shared-postgres-rw -U "$PGUSER" -d outline
+                   AND r.rolname = current_user" \
+                | psql -h shared-postgres-rw -U "$PGUSER" -d outline -v ON_ERROR_STOP=1
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary

- Replaces `REASSIGN OWNED BY CURRENT_USER TO outline` (which fails because the superuser owns system objects that cannot be transferred) with a generate-and-pipe approach
- Queries `pg_class` to generate targeted `ALTER TABLE/VIEW/SEQUENCE/MATERIALIZED VIEW ... OWNER TO outline;` statements for objects in the `public` schema owned by the current superuser, then pipes them into a second psql invocation
- Scoped to `r.rolname = current_user` so only superuser-owned objects are affected — objects owned by other roles (e.g. extensions) are left alone
- Adds `set -o pipefail` and `-v ON_ERROR_STOP=1` so failures in either psql invocation cause the job to fail visibly rather than silently succeeding

## Test plan

- [ ] Merge and sync the `core/postgres` ArgoCD app
- [ ] Confirm the `outline-ownership-fix` job completes without errors
- [ ] Restart the Outline pod and confirm the migration succeeds

https://claude.ai/code/session_01Mhjuv59wbBJ6bqYJ4kShzT