### PR TITLE
Add Jellyfin media service with pmcd.dev domain support

### DIFF
--- a/apps/media/jellyfin/httproute.yaml
+++ b/apps/media/jellyfin/httproute.yaml
@@ -10,7 +10,8 @@ spec:
       name: traefik-gateway
       namespace: default
   hostnames:
-    - jellyfin.x.pmcd.io  # TODO: replace with your actual domain
+    - jellyfin.x.pmcd.io
+    - jellyfin.pmcd.dev
   rules:
     - matches:
         - path:

--- a/apps/media/jellyfin/httproute.yaml
+++ b/apps/media/jellyfin/httproute.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: jellyfin-httproute
+  namespace: media
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: traefik-gateway
+      namespace: default
+  hostnames:
+    - jellyfin.x.pmcd.io  # TODO: replace with your actual domain
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: jellyfin
+          kind: Service
+          namespace: media
+          port: 8096

--- a/apps/media/jellyfin/kustomization.yaml
+++ b/apps/media/jellyfin/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service.yaml
+  - httproute.yaml

--- a/apps/media/jellyfin/service.yaml
+++ b/apps/media/jellyfin/service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jellyfin
+  namespace: media
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8096
+      protocol: TCP
+      targetPort: 8096
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: jellyfin
+  namespace: media
+subsets:
+  - addresses:
+      - ip: 192.168.1.210
+    ports:
+      - name: http
+        port: 8096
+        protocol: TCP

--- a/apps/media/media-apps.applicationset.yaml
+++ b/apps/media/media-apps.applicationset.yaml
@@ -55,6 +55,7 @@ spec:
     - list:
         elements:
           - name: bazarr
+          - name: jellyfin
           - name: lidarr
           - name: notifiarr
           - name: sabnzbd

--- a/core/cert-manager/certificate.yaml
+++ b/core/cert-manager/certificate.yaml
@@ -13,3 +13,17 @@ spec:
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: pmcddev-tls-le
+  namespace: default
+spec:
+  secretName: pmcddev-tls-le
+  dnsNames:
+    - "pmcd.dev"
+    - "*.pmcd.dev"
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer

--- a/core/traefik.yaml
+++ b/core/traefik.yaml
@@ -90,6 +90,7 @@ spec:
                   from: All
                 certificateRefs:
                   - name: pmcdio-tls-le
+                  - name: pmcddev-tls-le
           # Enable Observability
           logs:
             general:


### PR DESCRIPTION
## Summary
This PR adds Jellyfin media service to the cluster with routing configuration and extends TLS certificate support to include the pmcd.dev domain.

## Key Changes
- **Jellyfin Service Setup**: Added Kubernetes Service and Endpoints configuration for Jellyfin pointing to external IP `192.168.1.210:8096`
- **HTTPRoute Configuration**: Created HTTPRoute to expose Jellyfin via Traefik gateway on `jellyfin.x.pmcd.io` and `jellyfin.pmcd.dev` domains
- **TLS Certificate Expansion**: Added new Certificate resource for `pmcd.dev` domain and its wildcard subdomain to support the new Jellyfin domain
- **Traefik Gateway Update**: Registered the new `pmcddev-tls-le` certificate with the Traefik gateway listener
- **ApplicationSet Integration**: Added Jellyfin to the media apps ApplicationSet for automated deployment management

## Implementation Details
- Jellyfin is configured as a headless Service (clusterIP: None) with manual Endpoints pointing to an external media server
- Uses Gateway API (HTTPRoute) for ingress routing instead of traditional Ingress resources
- TLS certificates are managed via cert-manager with Let's Encrypt production issuer
- Jellyfin is integrated into the existing media namespace alongside other media applications (bazarr, lidarr, etc.)

https://claude.ai/code/session_01QhJ7FferezH5sRBLNAV8mL