### PR TITLE
Enable Renovate auto-merge for patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,10 @@
   ],
   "packageRules": [
     {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+    {
       "matchPackageNames": [
         "argo-cd"
       ],


### PR DESCRIPTION
Adds a packageRule that automerges patch releases by default. Existing
explicit automerge: false rules for ArgoCD, Infrastructure Charts (traefik,
cert-manager, external-secrets), Monitoring Stack, Longhorn, and Flannel
come later in packageRules and continue to suppress automerge for those
critical packages.

https://claude.ai/code/session_01GKq3UV5Pfoc8wnBTTpygEX