### PR TITLE
Add concertarr to media stack

### DIFF
--- a/apps/media/concertarr/values.yaml
+++ b/apps/media/concertarr/values.yaml
@@ -1,0 +1,67 @@
+image:
+  repository: ghcr.io/patrickjmcd/concertarr
+  tag: "v0.1.0"
+
+service:
+  port: 80
+  containerPort: 8000
+
+resources:
+  requests:
+    cpu: 15m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+probes:
+  readiness:
+    type: httpGet
+    path: /healthz
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 3
+  liveness:
+    enabled: true
+    type: httpGet
+    path: /healthz
+    initialDelaySeconds: 30
+    failureThreshold: 5
+    periodSeconds: 30
+    timeoutSeconds: 5
+  startup:
+    enabled: true
+    type: httpGet
+    path: /healthz
+    failureThreshold: 30
+    periodSeconds: 5
+
+httproute:
+  enabled: true
+  hostnames:
+    - concertarr.x.pmcd.io
+
+persistence:
+  enabled: true
+  type: longhorn
+  size: 1Gi
+  mountPath: /app/data
+
+imagePullSecrets:
+  - name: ghcr-registry-cred
+
+env:
+  TZ: America/Chicago
+  CONCERTARR_MEDIA_ROOT: /mnt/media/concerts
+  CONCERTARR_POLL_INTERVAL_MINUTES: "180"
+  CONCERTARR_PREFERRED_FORMATS: "Flac,VBR MP3,MP3,Ogg Vorbis"
+
+extraVolumes:
+  - name: media
+    persistentVolumeClaim:
+      claimName: smb-media-claim
+
+extraVolumeMounts:
+  - mountPath: /mnt/media
+    name: media

--- a/apps/media/concertarr/values.yaml
+++ b/apps/media/concertarr/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/patrickjmcd/concertarr
-  tag: "v0.1.0"
+  tag: "64d402d"
 
 service:
   port: 80
@@ -47,9 +47,6 @@ persistence:
   type: longhorn
   size: 1Gi
   mountPath: /app/data
-
-imagePullSecrets:
-  - name: ghcr-registry-cred
 
 env:
   TZ: America/Chicago

--- a/apps/media/media-apps.applicationset.yaml
+++ b/apps/media/media-apps.applicationset.yaml
@@ -16,6 +16,7 @@ spec:
           - name: hdhr2xmltv
           - name: seerr
           - name: medialyze
+          - name: concertarr
   template:
     metadata:
       name: '{{name}}'


### PR DESCRIPTION
Lidarr-style monitoring/auto-grab service for live concert recordings
on archive.org (etree collection). Uses SQLite on a small Longhorn
volume for app state and the shared SMB media claim for downloaded
audio, following the agregarr pattern.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YPRdDTSPH6yWqyhJJgDhvF