### PR TITLE
Add concertarr to media stack

### DIFF
--- a/apps/media/concertarr/values.yaml
+++ b/apps/media/concertarr/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/patrickjmcd/concertarr
-  tag: "64d402d"
+  tag: "d1a0ed3"
 
 service:
   port: 80


### PR DESCRIPTION
## Summary
- Adds `concertarr` (github.com/patrickjmcd/concertarr) to the media stack: a Lidarr-style service that monitors bands and auto-downloads newly added live recordings from archive.org (etree collection)
- Registers it in `media-apps.applicationset.yaml` alongside the existing Sonarr/Radarr/Lidarr/etc. apps, in the `media` namespace
- Uses SQLite on a 1Gi Longhorn volume for app state and the shared `smb-media-claim` (mounted under `concerts/`) for downloaded audio, following the `agregarr` pattern
- Pinned to a multi-arch (`linux/amd64` + `linux/arm64`) image build, after an initial amd64-only build failed to pull on the cluster's arm64 (Pi 5 / Jetson) nodes

## Test plan
- [ ] ArgoCD syncs `concertarr` cleanly in the `media` namespace
- [ ] Pod pulls the image successfully regardless of node architecture
- [ ] `concertarr.x.pmcd.io` is reachable and the dashboard loads
- [ ] Adding an artist and triggering "Check Now" discovers/queues a concert for download


---
_Generated by [Claude Code](https://claude.ai/code/session_01YPRdDTSPH6yWqyhJJgDhvF)_