### PR TITLE
Fix concertarr default search query (missed non-etree bands)

### DIFF
--- a/apps/media/concertarr/values.yaml
+++ b/apps/media/concertarr/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/patrickjmcd/concertarr
-  tag: "d1a0ed3"
+  tag: "233ed7d"
 
 service:
   port: 80


### PR DESCRIPTION
## Summary
- Bumps `concertarr` to a new image build (`233ed7d`) that fixes the default archive.org search query
- The old default (`collection:(etree) AND creator:("<name>")`) silently returned zero results for any artist whose recordings aren't tagged `etree` — confirmed via direct archive.org API testing that Wilco's 99 live recordings are scattered across `taperssection`, `hifidelity`, `folksoundomy`, `opensource_audio`, and individual tapers' personal collections instead
- New default drops the collection restriction (`creator:("<name>") AND mediatype:(audio)`), verified no regression against Grateful Dead (still 226 matches)

## Test plan
- [ ] ArgoCD syncs the new image tag
- [ ] Adding "Wilco" as a monitored artist now returns matches in the "Preview Matches" step
- [ ] Existing etree-scene artists (e.g. Grateful Dead) still return matches


---
_Generated by [Claude Code](https://claude.ai/code/session_01YPRdDTSPH6yWqyhJJgDhvF)_