### PR TITLE
Bump concertarr: manual concert selection

### DIFF
--- a/apps/media/concertarr/values.yaml
+++ b/apps/media/concertarr/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/patrickjmcd/concertarr
-  tag: "233ed7d"
+  tag: "122ca44"
 
 service:
   port: 80


### PR DESCRIPTION
## Summary
- Bumps `concertarr` to a new multi-arch image build (`122ca44`) that adds:
  - Per-artist `auto_download` toggle (default on, preserving current behavior) — when off, discovered concerts stay in `new` status instead of downloading automatically
  - Checkbox selection on the artist detail and library pages, with a "Download Selected" action
  - A "Download All New" bulk action, usable globally or scoped to one artist
  - A manual "Download Now" button on individual concert detail pages
- A lightweight startup migration (`ALTER TABLE ... ADD COLUMN`) handles existing SQLite databases picking up the new `auto_download` column without data loss

## Test plan
- [x] Verified locally end-to-end with the real archive.org API: created an artist with auto-download off, confirmed discovered concerts stay `new`, selected two via checkboxes, confirmed only those moved to `downloading`/`downloaded` while the rest stayed `new`
- [x] Verified the SQLite migration adds the column with the correct default for an existing (pre-feature) database
- [x] Verified no regression: default `auto_download=True` artists still auto-queue downloads as before
- [ ] ArgoCD syncs the new image tag in the cluster


---
_Generated by [Claude Code](https://claude.ai/code/session_01YPRdDTSPH6yWqyhJJgDhvF)_