### PR TITLE
Bump concertarr: React/shadcn frontend + track listings, discovery

### DIFF
--- a/apps/media/concertarr/values.yaml
+++ b/apps/media/concertarr/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/patrickjmcd/concertarr
-  tag: "122ca44"
+  tag: "a36b9fa"
 
 service:
   port: 80


### PR DESCRIPTION
## Summary
- Bumps `concertarr` to a new multi-arch image build (`a36b9fa`) covering two rounds of app changes:
  - **Frontend rewrite**: the server-rendered Jinja2 UI is replaced with a React + shadcn/ui SPA (Vite + TypeScript + Tailwind v4), served by the same FastAPI process (API under `/api/*`, SPA elsewhere with a catch-all fallback for client-side routing). No change to the deployment shape — still one container.
  - **New features**:
    - Concert detail pages now show the track list — actual files on disk once downloaded, or a live archive.org-metadata preview of what would be downloaded otherwise
    - Dashboard gets a "Recently Added on Archive.org" feed showing newest live recordings across the taping-community collections, regardless of whether the artist is monitored
    - New "Discover" page to browse/search artists with live recordings on archive.org, with a quick "Monitor" action that prefills the existing Add Artist flow
- Also fixed a latent bug in the dashboard endpoint (missing import) that would have crashed once any concerts existed

## Test plan
- [x] Verified both Docker build stages (frontend `npm run build`, backend serving the built assets) locally, then the actual multi-stage multi-arch build in CI (this run)
- [x] Verified the image manifest includes both `linux/amd64` and `linux/arm64`
- [x] Exercised the full app end-to-end in a real browser against the live archive.org API: dashboard, artist add/preview/search, checkbox selection and bulk/individual downloads, real FLAC downloads landing on disk, track list preview and disk-listing, discover search and quick-monitor flow, light/dark mode
- [ ] ArgoCD syncs the new image tag in the cluster


---
_Generated by [Claude Code](https://claude.ai/code/session_01YPRdDTSPH6yWqyhJJgDhvF)_