### PR TITLE
Bump concertarr: real track titles, non-concert flagging

### DIFF
--- a/apps/media/concertarr/values.yaml
+++ b/apps/media/concertarr/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/patrickjmcd/concertarr
-  tag: "a36b9fa"
+  tag: "9c1d751"
 
 service:
   port: 80


### PR DESCRIPTION
## Summary
- Bumps `concertarr` to a new multi-arch image build (`9c1d751`) covering two fixes:
  - **Real track titles**: the concert track list only showed raw derivative filenames (e.g. `wilco_1994-11-23t02.mp3`) instead of the actual song title. archive.org's per-file metadata includes proper `title`/`track`/`length` fields that weren't being used — now the track list shows real setlists, sorted by track number, using on-disk file size once downloaded.
  - **Non-concert flagging**: studio releases, remasters, and compilations sometimes turn up alongside real live recordings in creator/collection searches (verified against Wilco's real catalog — 4 non-concert items out of 99, e.g. "Spotify Singles", a demos comp, a SACD remaster). A heuristic (title contains "live", or a date pattern matching typical taper filenaming) flags these with a small warning icon across the artist preview, concert lists, dashboard feeds, and discover page — a browsing aid, not a hard filter, since it's inherently a heuristic rather than ground truth.

## Test plan
- [x] Verified the track-title fix against real archive.org metadata (correct titles, track numbers, lengths, sort order)
- [x] Verified the flagging heuristic against the real Wilco catalog: 0 false positives/negatives across all 99 items (95 real shows unflagged, 4 non-concert items flagged)
- [x] Exercised both in a real browser end-to-end: artist preview, discover page, dashboard feed
- [x] Verified the multi-arch image build in CI
- [ ] ArgoCD syncs the new image tag in the cluster


---
_Generated by [Claude Code](https://claude.ai/code/session_01YPRdDTSPH6yWqyhJJgDhvF)_