### PR TITLE
Bump concertarr: fix result truncation, show taper source

### DIFF
--- a/apps/media/concertarr/values.yaml
+++ b/apps/media/concertarr/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/patrickjmcd/concertarr
-  tag: "9c1d751"
+  tag: "3080139"
 
 service:
   port: 80


### PR DESCRIPTION
## Summary
- Bumps `concertarr` to a new multi-arch image build (`3080139`) covering two fixes:
  - **Fix silent result truncation**: both the initial poll and the "Preview Matches" flow only ever fetched a single page from archive.org (50 and 20 rows respectively) with no pagination. Any artist with more shows than that lost everything past the cutoff permanently, since later polls only look at what's newest. Verified against real data: Wilco (99 shows) was truncated to ~50, Grateful Dead (226 shows) would have lost more than half. New artists now backfill their full back catalog via pagination (capped at 500 by default, `CONCERTARR_MAX_BACKFILL_RESULTS`), and the preview UI shows the true total match count ("Showing 100 of 226 matches").
  - **Show the taper/uploader source**: archive.org's raw collection field mixes a specific taper's personal collection (e.g. "aadamjacobs", "NYCTaper") with generic scoping collections and often 200+ noisy `fav-*` favorites-list tags. This is now distilled into a clean "source" field, shown as a small "via aadamjacobs"-style tag next to titles (only when a distinctive source exists) and on the concert detail page, replacing the previous unreadable raw collection dump.

## Test plan
- [x] Verified pagination against real archive.org data: Wilco (99), John Mayer (36), and Grateful Dead (226, spanning 3 pages) all returned the exact total with no duplicates across page boundaries
- [x] Verified creating a Wilco artist now backfills all 99 shows instead of ~50
- [x] Verified source extraction against Wilco's full catalog: only the 4 items with a real distinctive taper source (2 aadamjacobs, 2 NYCTaper) are flagged, the other 95 correctly show none
- [x] Exercised both in a real browser end-to-end (Add Artist preview, concert detail)
- [x] Verified the multi-arch image build in CI
- [ ] ArgoCD syncs the new image tag in the cluster


---
_Generated by [Claude Code](https://claude.ai/code/session_01YPRdDTSPH6yWqyhJJgDhvF)_